### PR TITLE
Appropriately handle JS source map digests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,13 @@ ruby "2.3.0"
 
 gem "rails", "4.2.5.2"
 
-gem "haml-rails",   "~> 0.9.0"
-gem "passenger",    "~> 5.0.26"
-gem "pg",           "~> 0.18.4"
-gem "rack-timeout", "~> 0.3.2"
-gem "sass-rails",   "~> 5.0.4"
-gem "uglifier",     "~> 2.7.2"
+gem "haml-rails",               "~> 0.9.0"
+gem "passenger",                "~> 5.0.26"
+gem "pg",                       "~> 0.18.4"
+gem "rack-timeout",             "~> 0.3.2"
+gem "sass-rails",               "~> 5.0.4"
+gem "uglifier",                 "~> 2.7.2"
+gem "non-stupid-digest-assets", "~> 1.0.8"
 
 group :development do
   gem "foreman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     minitest (5.8.4)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    non-stupid-digest-assets (1.0.8)
+      sprockets (>= 2.0)
     parser (2.3.0.6)
       ast (~> 2.2)
     passenger (5.0.26)
@@ -228,6 +230,7 @@ DEPENDENCIES
   haml-rails (~> 0.9.0)
   haml_lint
   mailcatcher
+  non-stupid-digest-assets (~> 1.0.8)
   passenger (~> 5.0.26)
   pg (~> 0.18.4)
   pry-byebug

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,10 +7,11 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(*.bundle.js)
+# application.js, application.css, and all non-JS/CSS in app/assets folder are
+# already added.
+Rails.application.config.assets.precompile += [/.*\.bundle\.js$/]
 
-# Compiles whitelisted files to both digest and non-digest assets, allowing
-# the source map references in bui
+# Compiles whitelisted files to both digest and non-digest assets, allowing the
+# source map references in built files to work.
 # see: https://github.com/alexspeller/non-stupid-digest-assets
-NonStupidDigestAssets.whitelist += [/.*\.bundle\.js\.map/]
+NonStupidDigestAssets.whitelist += [/.*\.bundle\.js\.map$/]

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,9 @@ Rails.application.config.assets.version = "1.0"
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( app.bundle.js )
+Rails.application.config.assets.precompile += %w(*.bundle.js)
+
+# Compiles whitelisted files to both digest and non-digest assets, allowing
+# the source map references in bui
+# see: https://github.com/alexspeller/non-stupid-digest-assets
+NonStupidDigestAssets.whitelist += [/.*\.bundle\.js\.map/]


### PR DESCRIPTION
Webpack appends `// sourceMappingURL=app.bundle.js.map` to the end of the compiled JS bundle, but `rake assets:precompile` moves *app.bundle.js.map* to *app.bundle.js-[hash].map*.